### PR TITLE
Fix mocha deprecation warning

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 require 'test/unit'
-require 'mocha/setup'
+require 'mocha/test_unit'
 require 'tmpdir'
 require 'logger'
 require 'pp'


### PR DESCRIPTION
Requiring 'mocha/setup' was deprecated in mocha v1.10.0.